### PR TITLE
Modification: 235234343 to 235234344

### DIFF
--- a/data/photographers.json
+++ b/data/photographers.json
@@ -501,7 +501,7 @@
 			"price": 70
 		  },
 		{
-			"id": 235234343,
+			"id": 235234344,
 			"photographerId": 930,
 			"title": "Climber",
 			"image": "Sport_Next_Hold.jpg",


### PR DESCRIPTION
Two medias have the same identifier (line 441 and 504). It should not be the case, and could generate errors while fetching the data.